### PR TITLE
Background info on the Git plugin functionality

### DIFF
--- a/src/main/docs/guide/gradlegitproperties.adoc
+++ b/src/main/docs/guide/gradlegitproperties.adoc
@@ -1,6 +1,6 @@
 If a `git.properties` file is available on the classpath, the http://docs.micronaut.io/latest/api/io/micronaut/management/endpoint/info/source/GitInfoSource.html[GitInfoSource]
 will expose the values in that file under the `git` key. Generating of a `git.properties` file will need to be configured
-as part of your build; for example, you may choose to use the https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties[Gradle Git Properties] plugin.
+as part of your build; for example, you may choose to use the https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties[Gradle Git Properties] plugin. The plugin provides a task named `generateGitProperties` responsible for the `git.properties` file generation. It is automatically invoked upon the execution of the `classes` task. You can find the generated file in the directory `build/resources/main`.
 
 Modify `build.gradle` file to add the Gradle plugin:
 


### PR DESCRIPTION
Provide a bit more background information on how the plugin operates under the cover.